### PR TITLE
from-ts: Fix converting null when using TypeScript 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,26 @@
 language: node_js
 node_js:
-  - "node"
-script:
-  - npm run dist
+  - 12
 
-deploy:
-  provider: script
-  script: bash scripts/publish.sh
-  skip_cleanup: true
-  email: it@mural.co
-  on:
-    branch: master
+jobs:
+  include:
+    - stage: test
+      script: npm run lint
+      name: "Lint"
+    - script:
+      - npm install typescript@3
+      - npm test
+      name: "TypeScript 3"
+    - script:
+      - npm install typescript@4
+      - npm test
+      name: "TypeScript 4"
+    - stage: deploy
+      provider: script
+      script:
+      - npm run dist
+      - bash scripts/publish.sh
+      skip_cleanup: true
+      email: it@mural.co
+      on:
+        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ jobs:
       - bash scripts/publish.sh
       skip_cleanup: true
       email: it@mural.co
-      on:
-        branch: master
+      # Deploy on merge to master
+      if: type = push AND branch = master

--- a/features/from-ts.feature
+++ b/features/from-ts.feature
@@ -30,6 +30,16 @@ Scenario: Boolean
     };
     """
 
+Scenario: Null
+  Given a TS file with interface Some { key: null; }
+  When generating the schema from that file with exports
+  Then the generated schema is
+    """
+    export const Some = {
+      key: null,
+    };
+    """
+
 Scenario: Optional
   Given a TS file with interface Some { key?: string; }
   When generating the schema from that file with exports
@@ -333,6 +343,14 @@ Scenario: Number union
   Then the generated schema is
     """
     export const A = '1|2';
+    """
+
+Scenario: String and null union
+  Given a TS file with type A = string | null;
+  When generating the schema from that file with exports
+  Then the generated schema is
+    """
+    export const A = 'string|null';
     """
 
 Scenario: Generic dictionary

--- a/features/object.feature
+++ b/features/object.feature
@@ -1,5 +1,10 @@
 Feature: object
 
+Scenario: success null
+  Given a schema { "key": null }
+  When validating { "key": null }
+  Then the validation passes
+
 Scenario: success number
   Given a schema { "key": "number" }
   When validating { "key": 1 }
@@ -14,7 +19,8 @@ Scenario: success one of each
       "lu": "'a'|'b'",
       "n": "number",
       "o": { "child": "string" },
-      "s": "string"
+      "s": "string",
+      "u": null
     }
     """
   When validating
@@ -25,7 +31,8 @@ Scenario: success one of each
       "lu": "a",
       "n": 1,
       "o": { "child": "yeah" },
-      "s": "name"
+      "s": "name",
+      "u": null
     }
     """
   Then the validation passes

--- a/features/union.feature
+++ b/features/union.feature
@@ -50,6 +50,21 @@ Scenario: error string no matching type
   When validating true
   Then the validation error is "Expected number, string"
 
+Scenario: success string and null union against string
+  Given a schema "string|null"
+  When validating "good"
+  Then the validation passes
+
+Scenario: success string and null union against null
+  Given a schema "string|null"
+  When validating null
+  Then the validation passes
+
+Scenario: error string and null union
+  Given a schema "string|null"
+  When validating 1
+  Then the validation error is "Expected string, null"
+
 Scenario: return errors from best match
   Given a schema [[{"a": "number", "b": "number"}, {"a": "string", "c": "number"}]]
   When validating { "a": "hi" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mural-schema",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mural-schema",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "A JSON validation library using pure JSON schemas",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/from-ts/parse-to-ast.ts
+++ b/src/from-ts/parse-to-ast.ts
@@ -151,7 +151,11 @@ function generateType(type: ts.Node, options: Options): Ast {
   if (ts.isArrayTypeNode(type)) return generateArray(type, options);
   if (ts.isUnionTypeNode(type)) return generateUnion(type, options);
   if (ts.isTypeReferenceNode(type)) return generateTypeRef(type, options);
-  if (ts.isLiteralTypeNode(type)) return generateLiteral(type);
+  if (ts.isLiteralTypeNode(type))
+    // TypeScript 4 adds NullLiteral to LiteralTypeNode
+    return type.literal.kind === ts.SyntaxKind.NullKeyword
+      ? generateValue('null', null)
+      : generateLiteral(type);
   if (ts.isIntersectionTypeNode(type)) {
     return generateIntersectionObject(type, options);
   }


### PR DESCRIPTION
- Fix a problem where `from-ts` incorrect converts `null` TypeScript values  to `false` when using TypeScript 4.
-  Add tests for null values.
- CI: Run tests against both TypeScript 3 and 4.
- Increment package version.