### PR TITLE
to-jsonschema: Fix pattern keyword for strings

### DIFF
--- a/features/to-jsonschema.feature
+++ b/features/to-jsonschema.feature
@@ -35,3 +35,24 @@ Scenario: Object
 Scenario: Literal union
   When mapping to JSON schema "'a'|#b|`c`|\"d\""
   Then the resulting schema is { "enum": ["a", "b", "c", "d"] }
+
+Scenario: Regular expression
+  When mapping to JSON schema /^\d+$/
+  Then the resulting schema is
+    """
+    {
+      "pattern": "^\\d+$",
+      "type": "string"
+    }
+    """
+
+# JSON Schema doesn't support regular expression flags
+Scenario: Regular expression with flags
+  When mapping to JSON schema /^[A-Z]+$/i
+  Then the resulting schema is
+    """
+    {
+      "pattern": "^[A-Z]+$",
+      "type": "string"
+    }
+    """

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mural-schema",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "A JSON validation library using pure JSON schemas",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/test.ts
+++ b/src/test.ts
@@ -6,12 +6,24 @@ import toJsonSchema, { astToJsonSchema } from './to-jsonschema';
 
 astToJsonSchema; // pin down this reference
 
-const parseJSON = (s: string) =>
-  s === 'undefined'
-    ? undefined
-    : s.startsWith('/') && s.endsWith('/') && s.length > 1
-    ? new RegExp(s.substring(1, s.length - 1))
-    : JSON.parse(s);
+// Regular expression to match a regular expression literal
+const regExpRe = /^\/(.*)\/[dgimsuy]*$/;
+
+const parseJSON = (s: string) => {
+  // Literal 'undefined'
+  if (s === 'undefined') {
+    return undefined;
+  }
+
+  // Regular expression
+  const result = regExpRe.exec(s);
+  const pattern = result ? result[1] : null;
+  if (pattern) {
+    return new RegExp(pattern);
+  }
+
+  return JSON.parse(s);
+};
 
 const opts: S.ParseOptions = {
   customTypes: {

--- a/src/to-jsonschema/index.ts
+++ b/src/to-jsonschema/index.ts
@@ -74,7 +74,7 @@ const mapObject = (ast: ObjectAst, options: Options): JsonSchemaObject => ({
 });
 
 const mapRegExp = (ast: RegExpAst): JsonSchemaString => ({
-  pattern: ast.value,
+  pattern: ast.value.source,
   type: 'string',
 });
 

--- a/src/to-jsonschema/types.ts
+++ b/src/to-jsonschema/types.ts
@@ -33,7 +33,7 @@ export interface JsonSchemaObject {
 
 export interface JsonSchemaString {
   type: 'string';
-  pattern?: RegExp;
+  pattern?: string;
 }
 
 interface JsonSchemaUnion {


### PR DESCRIPTION
JSON Schema supports the `pattern` keyword to express constraints for strings as regular expressions: https://json-schema.org/understanding-json-schema/reference/regular_expressions.html

Update the to-jsonschema module to return `pattern` as a string instead of as a RegExp object. This ensures a valid `pattern` in the generated JSON Schema.

Note that JSON Schema doesn't support regular expression flags in its patterns.