### PR TITLE
to-jsonschema: Fix handling null schema

### DIFF
--- a/features/to-jsonschema.feature
+++ b/features/to-jsonschema.feature
@@ -36,6 +36,36 @@ Scenario: Literal union
   When mapping to JSON schema "'a'|#b|`c`|\"d\""
   Then the resulting schema is { "enum": ["a", "b", "c", "d"] }
 
+Scenario: String
+  When mapping to JSON schema "string"
+  Then the resulting schema is
+    """
+    {
+      "type": "string"
+    }
+    """
+
+Scenario: Null
+  When mapping to JSON schema "null"
+  Then the resulting schema is
+    """
+    {
+      "type": "null"
+    }
+    """
+
+Scenario: String and null union
+  When mapping to JSON schema "string|null"
+  Then the resulting schema is
+    """
+    {
+      "anyOf": [
+        { "type": "string" },
+        { "type": "null" }
+      ]
+    }
+    """
+
 Scenario: Regular expression
   When mapping to JSON schema /^\d+$/
   Then the resulting schema is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mural-schema",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "A JSON validation library using pure JSON schemas",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/to-jsonschema/index.ts
+++ b/src/to-jsonschema/index.ts
@@ -90,7 +90,7 @@ const mapValue = (ast: ValueAst<any>, options: Options): JsonSchema => {
   switch (ast.value) {
     case 'undefined':
       return {};
-    case 'null':
+    case null:
       return { type: 'null' };
     default:
       return mapCustom(ast, options);


### PR DESCRIPTION
Fix JSON Schema generation for the `null` schema.

Before this change the output is:

    {}

After this change the output is:

    { "type": "null" }

See https://json-schema.org/understanding-json-schema/reference/null.html.