### PR TITLE
to-jsonschema: Support `additionalProperties` keyword for objects

### DIFF
--- a/features/to-jsonschema.feature
+++ b/features/to-jsonschema.feature
@@ -28,7 +28,108 @@ Scenario: Object
         "b": { "type": "boolean" },
         "c": { "type": "string" }
       },
+      "required": ["a"],
+      "additionalProperties": false
+    }
+    """
+
+Scenario: Object array
+  When mapping to JSON schema
+    """
+    [
+      {
+        "a": "number",
+        "b?": "boolean",
+        "c": "string?"
+      }
+    ]
+    """
+  Then the resulting schema is
+    """
+    {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "a": { "type": "number" },
+          "b": { "type": "boolean" },
+          "c": { "type": "string" }
+        },
+        "required": ["a"],
+        "additionalProperties": false
+      }
+    }
+    """
+
+Scenario: Object with `$strict: false`
+  When mapping to JSON schema
+    """
+    {
+      "a": "number",
+      "b?": "boolean",
+      "c": "string?",
+      "$strict": false
+    }
+    """
+  Then the resulting schema is
+    """
+    {
+      "type": "object",
+      "properties": {
+        "a": { "type": "number" },
+        "b": { "type": "boolean" },
+        "c": { "type": "string" }
+      },
       "required": ["a"]
+    }
+    """
+
+Scenario: Object with `$any` key
+  When mapping to JSON schema
+    """
+    {
+      "$any": "number"
+    }
+    """
+  Then the resulting schema is
+    """
+    {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": {
+        "type": "number"
+      }
+    }
+    """
+
+Scenario: Nested object with `$any` key
+  When mapping to JSON schema
+    """
+    {
+      "a": "string",
+      "b?": {
+        "$any": "number"
+      }
+    }
+    """
+  Then the resulting schema is
+    """
+    {
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": {
+          "type": "object",
+          "properties": {},
+          "required": [],
+          "additionalProperties": {
+            "type": "number"
+          }
+        }
+      },
+      "required": ["a"],
+      "additionalProperties": false
     }
     """
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mural-schema",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "description": "A JSON validation library using pure JSON schemas",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/to-jsonschema/types.ts
+++ b/src/to-jsonschema/types.ts
@@ -24,6 +24,7 @@ interface JsonSchemaNumber {
 }
 
 export interface JsonSchemaObject {
+  additionalProperties?: false | JsonSchema;
   properties: {
     [key: string]: JsonSchema;
   };


### PR DESCRIPTION
Update JSON Schema generation to include the `additionalProperties` keyword for objects.

By default, object schemas disallow unknown keys. The generated JSON Schema now includes `additionalProperties: false`.

When an object schema includes `$strict: false` to allow unknown keys, the generated JSON Schema omits `additionalProperties`; JSON Schema allows additional properties by default.

When an object schema includes the `$any` key, the generated JSON Schema sets `additionalProperties` to the schema specified in the value of the `$any` key.

See https://json-schema.org/understanding-json-schema/reference/object.html#additional-properties.